### PR TITLE
Remove deprecation warning `warning: constant ::Fixnum is deprecated`

### DIFF
--- a/lib/ruby-nessus/core_ext/helpers.rb
+++ b/lib/ruby-nessus/core_ext/helpers.rb
@@ -1,4 +1,4 @@
-class Fixnum
+class Integer
 
   # Return a severity integer in words.
   # @return [String]


### PR DESCRIPTION
For ruby 2.4 compatibility